### PR TITLE
feature: add base url override

### DIFF
--- a/src/http-client.spec.ts
+++ b/src/http-client.spec.ts
@@ -31,6 +31,22 @@ describe('HTTP Client', () => {
       expect(typeof client.patch).toBe('function');
       expect(typeof client.delete).toBe('function');
     });
+
+    it('should allow overriding environment URL', async () => {
+      const client = createGigwageClient({
+        apiKey,
+        apiSecret,
+        apiEnvironment: 'sandbox',
+        baseUrl: 'http://localhost:3000',
+      });
+
+      await client.get('/api/v1/contractors');
+      const mockArg = mockRequest.mock.calls[0][0];
+
+      expect(mockArg).toMatchObject({
+        url: 'http://localhost:3000/api/v1/contractors',
+      });
+    });
   });
 
   describe(`createHttpClient.get`, () => {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -65,6 +65,7 @@ interface ICreateHttpClientOptions {
   apiEnvironment?: GigwageEnvironments;
   apiKey: string;
   apiSecret: string;
+  baseUrl?: string;
 }
 
 /**
@@ -74,7 +75,10 @@ export const createHttpClient = ({
   apiKey,
   apiEnvironment = 'production',
   apiSecret,
+  baseUrl: baseUrlOverride,
 }: ICreateHttpClientOptions) => {
+  const baseUrl = baseUrlOverride ?? ENVIRONMENTS[apiEnvironment];
+
   /**
    * Calls a GET request to Gig Wage API.
    *
@@ -83,7 +87,7 @@ export const createHttpClient = ({
   const get = <ResponseData = any>(
     endpoint: string,
   ): Promise<AxiosResponse<ResponseData, any>> => {
-    const url = `${ENVIRONMENTS[apiEnvironment]}${endpoint}`;
+    const url = `${baseUrl}${endpoint}`;
     const method = 'GET';
     const headers = generateRequestHeaders({
       apiSecret,
@@ -104,7 +108,7 @@ export const createHttpClient = ({
     endpoint: string,
     data: object = {},
   ): Promise<AxiosResponse<ResponseData, any>> => {
-    const url = `${ENVIRONMENTS[apiEnvironment]}${endpoint}`;
+    const url = `${baseUrl}${endpoint}`;
     const method = 'POST';
     const headers = generateRequestHeaders({
       apiSecret,
@@ -130,7 +134,7 @@ export const createHttpClient = ({
     endpoint: string,
     data: object = {},
   ): Promise<AxiosResponse<ResponseData, any>> => {
-    const url = `${ENVIRONMENTS[apiEnvironment]}${endpoint}`;
+    const url = `${baseUrl}${endpoint}`;
     const method = 'PATCH';
     const headers = generateRequestHeaders({
       apiSecret,
@@ -156,7 +160,7 @@ export const createHttpClient = ({
   const del = async <ResponseData = any>(
     endpoint: string,
   ): Promise<AxiosResponse<ResponseData, any>> => {
-    const url = `${ENVIRONMENTS[apiEnvironment]}${endpoint}`;
+    const url = `${baseUrl}${endpoint}`;
     const method = 'DELETE';
     const headers = generateRequestHeaders({
       apiSecret,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,21 @@ interface IGigwageClientOptions {
    */
   apiKey: string;
   /**
-   * Gig Wage API key
+   * Gig Wage API Secret
    *
    * Learn more about Gig Wage API keys at https://developers.gigwage.com/#introduction
    */
   apiSecret: string;
+
+  /**
+   * *TESTING ONLY*
+   *
+   * When set, will override the apiEnvironment and use the provided base URL.
+   *
+   * Use pattern `https://www.gigwage.com`.
+   *
+   */
+  baseUrl?: string;
 }
 
 /**
@@ -27,8 +37,14 @@ export const createGigwageClient = ({
   apiEnvironment = 'production',
   apiKey,
   apiSecret,
+  baseUrl,
 }: IGigwageClientOptions) => {
-  const httpClient = createHttpClient({ apiSecret, apiKey, apiEnvironment });
+  const httpClient = createHttpClient({
+    apiSecret,
+    apiKey,
+    apiEnvironment,
+    baseUrl,
+  });
 
   return {
     ...httpClient,


### PR DESCRIPTION
- adds `baseUrl` option to the client for specifying which URL the API requests should be sent to.
- This should only be used for Internal testing.