### PR TITLE
to support params when do GET request

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -119,7 +119,7 @@ export const createHttpClient = ({
     return axios.request<ResponseData>({
       url,
       headers,
-      params
+      params,
     });
   };
 


### PR DESCRIPTION
This request will be rejected as we're using digest encryption: 
```
client.get('/api/v1/contractors?per_page=3&page=1').then(r => console.log(r)).catch(err => console.error(err));
```

And must do like this: 
```
client.get('/api/v1/contractors', { per_page: 3, page: 1 }).then(r => console.log(r)).catch(err => console.error(err));
```