### PR TITLE
Fix axios version

### DIFF
--- a/workspaces/client/package.json
+++ b/workspaces/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gigwage/client",
   "type": "commonjs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Node client library for accessing the Gig Wage API",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/workspaces/client/package.json
+++ b/workspaces/client/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "axios": "^1.1.3",
-    "crypto-js": "^4.1.1"
+    "axios": "1.1.3",
+    "crypto-js": "4.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,7 +987,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.1.3:
+axios@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.3.tgz#8274250dada2edf53814ed7db644b9c2866c1e35"
   integrity sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==
@@ -1244,7 +1244,7 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@^4.1.1:
+crypto-js@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==


### PR DESCRIPTION
Axios was automatically getting upgraded on clients because the version wasn't locked. This PR locks the dependency versions to prevent API change issues.